### PR TITLE
Minor updates in 1.2 to 1.3 upgrade guide

### DIFF
--- a/posts/blog--phoenix-1-3-0-released.markdown
+++ b/posts/blog--phoenix-1-3-0-released.markdown
@@ -133,14 +133,14 @@ application directory structure:
 
     lib
     ├── my_app
-    │  ├── acccounts
-    │  │   ├── accounts.ex
-    │  │   └── user.ex
-    │  ├── sales
-    │  │   ├── manager.ex
-    │  │   ├── sales.ex
-    │  │   └── ticket.ex
-    │  └── repo.ex
+    │   ├── acccounts
+    │   │   ├── accounts.ex
+    │   │   └── user.ex
+    │   ├── sales
+    │   │   ├── manager.ex
+    │   │   ├── sales.ex
+    │   │   └── ticket.ex
+    │   └── repo.ex
     ├── my_app.ex
     ├── my_app_web
     │   ├── channels

--- a/posts/blog--upgrading-from-120-to-130.markdown
+++ b/posts/blog--upgrading-from-120-to-130.markdown
@@ -123,7 +123,7 @@ Migrate your files to the new structure with the following steps:
   * `MyApp.UserSocket` => `MyAppWeb.UserSocket`
   * etc
 
-7. Update all alias in `lib/app_name_web/router.ex` to include new `Web` namespace. Most likely you can accomplish this by adding `Web` to the second argument of your scope blocks, for example:
+7. Update all aliases in `lib/app_name_web/router.ex` to include new `Web` namespace. Most likely you can accomplish this by adding `Web` to the second argument of your scope blocks, for example:
 
   ```diff
   - defmodule MyApp.Router do
@@ -151,7 +151,9 @@ Migrate your files to the new structure with the following steps:
   +   plug MyAppWeb.Router
   ```
 
-8. in `lib/my_app.ex`, update your children to reference the new endpoint and remove the config_change callback:
+8. Rename `lib/my_app.ex` to `lib/my_app/application.ex` and `MyApp` to `MyApp.Application`
+8. in `mix.exs`, change `mod: {MyApp, []}` to `mod: {MyApp.Application, []}`
+8. in `lib/my_app/application.ex`, update your children to reference the new endpoint and remove the `config_change` callback:
 
 ```diff
     ...
@@ -169,7 +171,7 @@ Migrate your files to the new structure with the following steps:
 - end
 ```
 
-8. Update all endpoint aliases in config/*.exs (config.exs, prod.exs, prod.secret.exs dev.exs, test.exs, etc) aliases to use new `Web` namespace:
+8. Update all endpoint aliases in `config/*.exs` (`config.exs`, `prod.exs`, `prod.secret.exs`, `dev.exs`, `test.exs`, etc) to use new `Web` namespace:
 
   ```diff
   - config :my_app, MyApp.Endpoint,

--- a/posts/blog--upgrading-from-120-to-130.markdown
+++ b/posts/blog--upgrading-from-120-to-130.markdown
@@ -55,266 +55,264 @@ The root level `web/` directory for new projects has been removed in favor of `l
 Migrate your files to the new structure with the following steps:
 
 1. `$ cd my_app`
-2. `$ mv web/web.ex lib/my_app_web.ex`
-2. `$ mv web lib/my_app_web`
-3. `$ mv lib/my_app/endpoint.ex lib/my_app_web/`
-4. Update your view root path in `lib/my_app_web.ex` to point to the new template location, and add the `:namespace` option:
+1. `$ mv web/web.ex lib/my_app_web.ex`
+1. `$ mv web lib/my_app_web`
+1. `$ mv lib/my_app/endpoint.ex lib/my_app_web/`
+1. Update your view root path in `lib/my_app_web.ex` to point to the new template location, and add the `:namespace` option:
 
-  ```diff
-    def view do
-      quote do
-  -      use Phoenix.View, root: "web/templates"
-  +      use Phoenix.View, root: "lib/my_app_web/templates",
-  +                        namespace: MyAppWeb
+   ```diff
+     def view do
+       quote do
+   -      use Phoenix.View, root: "web/templates"
+   +      use Phoenix.View, root: "lib/my_app_web/templates",
+   +                        namespace: MyAppWeb
+          ...
+   ```
+
+1. Add the namespace option to your `controller` definition in `web.ex`:
+
+   ```diff
+     def controller do
+       quote do
+   -     use Phoenix.Controller
+   +     use Phoenix.Controller, namespace: MyAppWeb
+   ```
+
+1. Update your aliases in web.ex `controller`, `view`, and `channel` definitions to use the new `Web` namespace:
+
+   ```diff
+     def controller do
+       quote do
          ...
-  ```
-
-4. Add the namespace option to your `controller` definition in `web.ex`:
-
-  ```diff
-    def controller do
-      quote do
-  -     use Phoenix.Controller
-  +     use Phoenix.Controller, namespace: MyAppWeb
-  ```
-
-
-5. Update your aliases in web.ex `controller`, `view`, and `channel` definitions to use the new `Web` namespace:
-
-  ```diff
-    def controller do
-      quote do
-        ...
-  -     import MyApp.Router.Helpers
-  +     import MyAppWeb.Router.Helpers
-  -     import MyApp.Gettext
-  +     import MyAppWeb.Gettext
-      end
-    end
-
-    def view do
-      quote do
-        ...
-  -     import MyApp.Router.Helpers
-  +     import MyAppWeb.Router.Helpers
-  -     import MyApp.ErrorHelpers
-  +     import MyAppWebErrorHelpers
-  -     import MyApp.Gettext
-  +     import MyAppWeb.Gettext
-      end
-    end
-
-    def channel do
-      quote do
-        ...
-  -     import MyApp.Gettext
-  +     import MyAppWeb.Gettext
-      end
-    end
-  ```
-
-
-6. Rename all web related modules in `lib/my_app_web/` (`gettext.ex`, `controllers/*`, `views/*`, `channels/*`, `endpoint.ex`, `router.ex`) to include a `Web` namespace, for example:
-
-  * `MyApp.Endpoint` => `MyAppWeb.Endpoint`
-  * `MyApp.Router` => `MyAppWeb.Router`
-  * `MyApp.PageController` => `MyAppWeb.PageController`
-  * `MyApp.PageView` => `MyAppWeb.PageView`
-  * `MyApp.UserSocket` => `MyAppWeb.UserSocket`
-  * etc
-
-7. Update all aliases in `lib/app_name_web/router.ex` to include new `Web` namespace. Most likely you can accomplish this by adding `Web` to the second argument of your scope blocks, for example:
-
-  ```diff
-  - defmodule MyApp.Router do
-  + defmodule MyAppWeb.Router do
-    ...
-  -   scope "/", MyApp do
-  +   scope "/", MyAppWeb do
-        pipe_through :browser
-
-        resources "/users", UserController
-        ...
+   -     import MyApp.Router.Helpers
+   +     import MyAppWeb.Router.Helpers
+   -     import MyApp.Gettext
+   +     import MyAppWeb.Gettext
+       end
      end
-  ```
 
-8. Update `endpoint.ex` to use new web modules:
+     def view do
+       quote do
+         ...
+   -     import MyApp.Router.Helpers
+   +     import MyAppWeb.Router.Helpers
+   -     import MyApp.ErrorHelpers
+   +     import MyAppWebErrorHelpers
+   -     import MyApp.Gettext
+   +     import MyAppWeb.Gettext
+       end
+     end
 
-  ```diff
-  - defmodule MyApp.Endpoint do
-  + defmodule MyAppWeb.Endpoint do
-      ...
-  -   socket "/socket", MyApp.UserSocket
-  +   socket "/socket", MyAppWeb.UserSocket
-      ...
-  -   plug MyApp.Router
-  +   plug MyAppWeb.Router
-  ```
+     def channel do
+       quote do
+         ...
+   -     import MyApp.Gettext
+   +     import MyAppWeb.Gettext
+       end
+     end
+   ```
 
-8. Rename `lib/my_app.ex` to `lib/my_app/application.ex` and `MyApp` to `MyApp.Application`
-8. in `mix.exs`, change `mod: {MyApp, []}` to `mod: {MyApp.Application, []}`
-8. in `lib/my_app/application.ex`, update your children to reference the new endpoint and remove the `config_change` callback:
+1. Rename all web related modules in `lib/my_app_web/` (`gettext.ex`, `controllers/*`, `views/*`, `channels/*`, `endpoint.ex`, `router.ex`) to include a `Web` namespace, for example:
 
-```diff
-    ...
-    children = [
-      ...
--     supervisor(MyApp.Endpoint, []),
-+     supervisor(MyAppWeb.Endpoint, []),
-      ...
-    ]
+   * `MyApp.Endpoint` => `MyAppWeb.Endpoint`
+   * `MyApp.Router` => `MyAppWeb.Router`
+   * `MyApp.PageController` => `MyAppWeb.PageController`
+   * `MyApp.PageView` => `MyAppWeb.PageView`
+   * `MyApp.UserSocket` => `MyAppWeb.UserSocket`
+   * etc
 
-  ...
-- def config_change(changed, _new, removed) do
--   MyApp.Endpoint.config_change(changed, removed)
--   :ok
-- end
-```
+1. Update all aliases in `lib/app_name_web/router.ex` to include new `Web` namespace. Most likely you can accomplish this by adding `Web` to the second argument of your scope blocks, for example:
 
-8. Update all endpoint aliases in `config/*.exs` (`config.exs`, `prod.exs`, `prod.secret.exs`, `dev.exs`, `test.exs`, etc) to use new `Web` namespace:
+   ```diff
+   - defmodule MyApp.Router do
+   + defmodule MyAppWeb.Router do
+     ...
+   -   scope "/", MyApp do
+   +   scope "/", MyAppWeb do
+         pipe_through :browser
 
-  ```diff
-  - config :my_app, MyApp.Endpoint,
-  + config :my_app, MyAppWeb.Endpoint,
-      ...
-  -   render_errors: [view: MyApp.ErrorView, accepts: ~w(html json)],
-  +   render_errors: [view: MyAppWeb.ErrorView, accepts: ~w(html json)],
-    ...
-  ```
-
-9. Update your live-reload patterns config in `config/dev.exs`:
-
-  ```diff
-  - config :my_app, MyApp.Endpoint,
-  + config :my_app, MyAppWeb.Endpoint,
-      live_reload: [
-        patterns: [
-          ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
-          ~r{priv/gettext/.*(po)$},
-  -       ~r{web/views/.*(ex)$},
-  -       ~r{web/templates/.*(eex)$}
-  +       ~r{lib/my_app_web/views/.*(ex)$},
-  +       ~r{lib/my_app_web/templates/.*(eex)$}
-        ]
-      ]
-  ```
-
-10. Rename your `test/support/conn_case.ex` and `test/support/channel_case.ex` modules to include `Web` namespace, and update `@endpoint` and router aliases in each:
-
-  ```diff
-  -defmodule MyApp.ConnCase do
-  +defmodule MyAppWeb.ConnCase do
-    using do
-      quote do
-        ...
-  -     import MyApp.Router.Helpers
-  +     import MyAppWeb.Router.Helpers
-
-        # The default endpoint for testing
-  -     @endpoint MyApp.Endpoint
-  +     @endpoint MyAppWeb.Endpoint
+         resources "/users", UserController
+         ...
       end
-    end
-    ...
+   ```
+
+1. Update `endpoint.ex` to use new web modules:
+
+   ```diff
+   - defmodule MyApp.Endpoint do
+   + defmodule MyAppWeb.Endpoint do
+       ...
+   -   socket "/socket", MyApp.UserSocket
+   +   socket "/socket", MyAppWeb.UserSocket
+       ...
+   -   plug MyApp.Router
+   +   plug MyAppWeb.Router
+   ```
+
+1. Rename `lib/my_app.ex` to `lib/my_app/application.ex` and `MyApp` to `MyApp.Application`
+1. in `mix.exs`, change `mod: {MyApp, []}` to `mod: {MyApp.Application, []}`
+1. in `lib/my_app/application.ex`, update your children to reference the new endpoint and remove the `config_change` callback:
+
+   ```diff
+       ...
+       children = [
+         ...
+   -     supervisor(MyApp.Endpoint, []),
+   +     supervisor(MyAppWeb.Endpoint, []),
+         ...
+       ]
+
+     ...
+   - def config_change(changed, _new, removed) do
+   -   MyApp.Endpoint.config_change(changed, removed)
+   -   :ok
+   - end
+   ```
+
+1. Update all endpoint aliases in `config/*.exs` (`config.exs`, `prod.exs`, `prod.secret.exs`, `dev.exs`, `test.exs`, etc) to use new `Web` namespace:
+
+   ```diff
+   - config :my_app, MyApp.Endpoint,
+   + config :my_app, MyAppWeb.Endpoint,
+       ...
+   -   render_errors: [view: MyApp.ErrorView, accepts: ~w(html json)],
+   +   render_errors: [view: MyAppWeb.ErrorView, accepts: ~w(html json)],
+     ...
+   ```
+
+1. Update your live-reload patterns config in `config/dev.exs`:
+
+   ```diff
+   - config :my_app, MyApp.Endpoint,
+   + config :my_app, MyAppWeb.Endpoint,
+       live_reload: [
+         patterns: [
+           ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
+           ~r{priv/gettext/.*(po)$},
+   -       ~r{web/views/.*(ex)$},
+   -       ~r{web/templates/.*(eex)$}
+   +       ~r{lib/my_app_web/views/.*(ex)$},
+   +       ~r{lib/my_app_web/templates/.*(eex)$}
+         ]
+       ]
+   ```
+
+1. Rename your `test/support/conn_case.ex` and `test/support/channel_case.ex` modules to include `Web` namespace, and update `@endpoint` and router aliases in each:
+
+   ```diff
+   -defmodule MyApp.ConnCase do
+   +defmodule MyAppWeb.ConnCase do
+     using do
+       quote do
+         ...
+   -     import MyApp.Router.Helpers
+   +     import MyAppWeb.Router.Helpers
+
+         # The default endpoint for testing
+   -     @endpoint MyApp.Endpoint
+   +     @endpoint MyAppWeb.Endpoint
+       end
+     end
+     ...
 
 
-  -defmodule MyApp.ChannelCase do
-  +defmodule MyAppWeb.ChannelCase do
+   -defmodule MyApp.ChannelCase do
+   +defmodule MyAppWeb.ChannelCase do
 
-    using do
-      quote do
-        ...
-  -     @endpoint MyApp.Endpoint
-  +     @endpoint MyAppWeb.Endpoint
-      end
-    end
-    ...
-  ```
+     using do
+       quote do
+         ...
+   -     @endpoint MyApp.Endpoint
+   +     @endpoint MyAppWeb.Endpoint
+       end
+     end
+     ...
+   ```
 
-11. Update all `test/*/**.exs` references to `use MyApp.ConnCase` or `use MyApp.ChannelCase` to use new `MyAppWeb.ConnCase` and `MyAppWeb.ChannelCase` aliases.
+1. Update all `test/*/**.exs` references to `use MyApp.ConnCase` or `use MyApp.ChannelCase` to use new `MyAppWeb.ConnCase` and `MyAppWeb.ChannelCase` aliases.
 
 ### Move static assets inside self-contained assets/ directory
 
 New projects now include a root-level `assets/` directory, which serves as a self-contained location for your asset builder's config, source files, and packages. This changer keeps things like `node_modules`, `package.json`, and `brunch-config.js` from leaking into the root of your elixir application. Update your app to the new structure by following these steps:
 
-1) move all `web/static/` sources into `assets/`, followed by `package.json`, `node_modules`, and `brunch-config.js`
+1. move all `web/static/` sources into `assets/`, followed by `package.json`, `node_modules`, and `brunch-config.js`
 
-  ```console
-  $ mv mv lib/my_app_web/static assets/
-  $ mv assets/assets assets/static
-  $ mv package.json assets/
-  $ mv brunch-config.js assets/
-  $ rm -rf node_modules
-  ```
+   ```console
+   $ mv mv lib/my_app_web/static assets/
+   $ mv assets/assets assets/static
+   $ mv package.json assets/
+   $ mv brunch-config.js assets/
+   $ rm -rf node_modules
+   ```
 
-2) Update your `asset/package.json` `phoenix` and `phoenix_html` paths:
+1. Update your `asset/package.json` `phoenix` and `phoenix_html` paths:
 
-  ```diff
-    "dependencies": {
-  -   "phoenix": "file:deps/phoenix",
-  +   "phoenix": "file:../deps/phoenix",
-  -   "phoenix_html": "file:deps/phoenix_html"
-  +   "phoenix_html": "file:../deps/phoenix_html"
-    },
-  ```
-
-
-3) Update your `assets/brunch-config.js` to be aware of the new conventions:
-
-  ```diff
-    conventions: {
-  -   // This option sets where we should place non-css and non-js assets in.
-  -   // By default, we set this to "/web/static/assets". Files in this directory
-  -   // will be copied to `paths.public`, which is "priv/static" by default.
-  -   assets: /^(web\/static\/assets)/
-  +   // This option sets where we should place non-css and non-js assets in.
-  +   // By default, we set this to "/assets/static". Files in this directory
-  +   // will be copied to `paths.public`, which is "priv/static" by default.
-  +   assets: /^(static)/
-    },
-
-    paths: {
-      // Dependencies and current project directories to watch
-  -   watched: [
-  -     "web/static",
-  -     "test/static"
-  -   ],
-  +   watched: ["static", "css", "js", "vendor"],
-
-      // Where to compile files to
-  -   public: "priv/static"
-  +   public: "../priv/static"
-    },
-
-    plugins: {
-      babel: {
-        // Do not use ES6 compiler in vendor code
-  -     ignore: [/web\/static\/vendor/]
-  +     ignore: [/vendor/]
-      }
-    },
-
-    modules: {
-      autoRequire: {
-  -     "js/app.js": ["web/static/js/app"]
-  +     "js/app.js": ["js/app"]
-      }
-    },
-  ```
-
-4) Update your `config/dev.exs` watcher to run in the new assets directory:
-
-  ```diff
-  config :my_app, MyAppWeb.Endpoint,
-    ...
-    watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-  -                  cd: Path.expand("../", __DIR__)]]
-  +                  cd: Path.expand("../assets", __DIR__)]]
+   ```diff
+     "dependencies": {
+   -   "phoenix": "file:deps/phoenix",
+   +   "phoenix": "file:../deps/phoenix",
+   -   "phoenix_html": "file:deps/phoenix_html"
+   +   "phoenix_html": "file:../deps/phoenix_html"
+     },
+   ```
 
 
-  ```
+1. Update your `assets/brunch-config.js` to be aware of the new conventions:
 
-5. Install the node deps: `$cd assets && npm install`
+   ```diff
+     conventions: {
+   -   // This option sets where we should place non-css and non-js assets in.
+   -   // By default, we set this to "/web/static/assets". Files in this directory
+   -   // will be copied to `paths.public`, which is "priv/static" by default.
+   -   assets: /^(web\/static\/assets)/
+   +   // This option sets where we should place non-css and non-js assets in.
+   +   // By default, we set this to "/assets/static". Files in this directory
+   +   // will be copied to `paths.public`, which is "priv/static" by default.
+   +   assets: /^(static)/
+     },
+
+     paths: {
+       // Dependencies and current project directories to watch
+   -   watched: [
+   -     "web/static",
+   -     "test/static"
+   -   ],
+   +   watched: ["static", "css", "js", "vendor"],
+
+       // Where to compile files to
+   -   public: "priv/static"
+   +   public: "../priv/static"
+     },
+
+     plugins: {
+       babel: {
+         // Do not use ES6 compiler in vendor code
+   -     ignore: [/web\/static\/vendor/]
+   +     ignore: [/vendor/]
+       }
+     },
+
+     modules: {
+       autoRequire: {
+   -     "js/app.js": ["web/static/js/app"]
+   +     "js/app.js": ["js/app"]
+       }
+     },
+   ```
+
+1. Update your `config/dev.exs` watcher to run in the new assets directory:
+
+   ```diff
+   config :my_app, MyAppWeb.Endpoint,
+     ...
+     watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+   -                  cd: Path.expand("../", __DIR__)]]
+   +                  cd: Path.expand("../assets", __DIR__)]]
+
+
+   ```
+
+1. Install the node deps: `$cd assets && npm install`
 
 
 Test it all with `mix phx.server`, and `mix test` and you should see:


### PR DESCRIPTION
1. Add section about changing `lib/my_app.ex` to `lib/my_app/application.ex`
1. Fix numbering by using markdown autonumbering and changing 2 spaces to 3 spaces indent for code blocks. Because of whitespace change it makes it painful to review so here's output of: `git diff origin/master..wm-update-upgrade-guide -w`: https://gist.github.com/wojtekmach/f741fb06e2ac0293587ac4ed89b066a4
1. Minor edits (remove typos etc)
1. Fix whitespace in project structure (again 😅 )