### PR TITLE
Fix typo in 1.3 release notes

### DIFF
--- a/posts/blog--phoenix-1-3-0-released.markdown
+++ b/posts/blog--phoenix-1-3-0-released.markdown
@@ -128,7 +128,7 @@ Designing with contexts gives you a solid foundation to grow your
 application from. Using discrete, well-defined APIs that expose the
 intent of your system allows you to write more maintainable
 applications with reusable code. Additionally, we can get a glimpse of
-what the application does and its feature-set just be exploring the
+what the application does and its feature-set just by exploring the
 application directory structure:
 
     lib


### PR DESCRIPTION
Changed `be` to `by`. Super minor though. 

:confetti_ball: