### PR TITLE
Fix blog links to Ecto guide

### DIFF
--- a/posts/blog--file-uploads.markdown
+++ b/posts/blog--file-uploads.markdown
@@ -12,7 +12,7 @@ Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `
 
 Let's take this one piece at a time.
 
-In the [`Ecto Models Guide`](ecto_models.html), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
+In the [`Ecto Guide`](https://hexdocs.pm/phoenix/ecto.html), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
 
 The first thing we need to do is change our form into a multipart form. The `form_for/4` function accepts a keyword list of options where we can specify this.
 

--- a/posts/blog--seeding-data.markdown
+++ b/posts/blog--seeding-data.markdown
@@ -10,7 +10,7 @@ When creating an app, it's important that we're able to seed our datastore with 
 
 Fortunately, Phoenix already provides us with a convention for seeding data. By default Phoenix generates a script file for each app at `priv/repo/seeds.exs`, which we can use to populate our datastore.
 
-Also note that in order to seed data as in the example below you should have already generated and run the related migration (i.e., Link migration, controller, model, etc.) and updated your `router.ex`, as described in the [Ecto Models Guide](ecto_models.html) (if you haven't completed that Guide yet, you should do so before proceeding further).
+Also note that in order to seed data as in the example below you should have already generated and run the related migration (i.e., Link migration, controller, model, etc.) and updated your `router.ex`, as described in the [Ecto Guide](https://hexdocs.pm/phoenix/ecto.html) (if you haven't completed that Guide yet, you should do so before proceeding further).
 
 So in order to seed data, we simply need to add a script to `seeds.exs` that uses our datastore to directly add the data we want. As you can see from the comments that Phoenix generated for us in `seeds.exs` file, we should follow this pattern:
 


### PR DESCRIPTION
Fix a couple of broken Ecto ~Models~ Guide links using absolute URLs to hexdocs.pm.