### PR TITLE
Improve homepage layout on very small screens

### DIFF
--- a/themes/default/assets/css/base.css
+++ b/themes/default/assets/css/base.css
@@ -2978,7 +2978,7 @@ scope,
     background-color: #917698
 }
 .header #jumbotron {
-    margin: 55px 70px 50px;
+    margin-top: 55px;
     text-align: center;
 }
 .header #jumbotron h2 {
@@ -14345,7 +14345,7 @@ h6 {
     background: rgba(255, 255, 255, 0.07);
     border: 3px solid #FEF4F2;
     height: 80px;
-    width: 340px;
+    max-width: 340px;
     box-sizing: border-box;
     padding-top: 14px;
     border-radius: 48px;

--- a/themes/default/layout/index.eex
+++ b/themes/default/layout/index.eex
@@ -23,18 +23,18 @@
         <div>
           <div id="subheader-columns">
             <div class="row">
-              <div class="col-xs-4 subheader">
+              <div class="col-sm-4 subheader">
                 <h4>How is Phoenix different?</h4>
                 <p>Phoenix brings back the simplicity and joy in writing modern web applications by mixing tried and true technologies with a fresh breeze of functional ideas.
                   <a class="subheader-link" href="https://hexdocs.pm/phoenix/up_and_running.html">Get started with Phoenix</a></p>
               </div>
-              <div class="col-xs-4 subheader">
+              <div class="col-sm-4 subheader">
                 <h4>Building the new web</h4>
                 <p>Create rich, interactive experiences across browsers, native mobile apps, and embedded devices with our real-time streaming technology called Channels.
                   <a class="subheader-link" href="https://hexdocs.pm/phoenix/channels.html">Learn about channels</a></p>
                 <p></p>
               </div>
-              <div class="col-xs-4 subheader">
+              <div class="col-sm-4 subheader">
                 <h4>Battle-proven technology</h4>
                 <p>Phoenix leverages the Erlang VM ability to handle millions of connections alongside Elixir's beautiful syntax and productive tooling for building fault-tolerant systems.
                   <a class="subheader-link" href="http://elixir-lang.org/">More about Elixir &amp; the Erlang VM</a></p>


### PR DESCRIPTION
Fixes the button overflowing the page and very short line lengths on some resolutions.
Before (iPhone 5S): https://imgur.com/a/1tdmI
After: https://imgur.com/a/KB0OU
