### PR TITLE
Remove phoenix-talk reference from Community

### DIFF
--- a/docs/community.html
+++ b/docs/community.html
@@ -59,7 +59,7 @@
       <div class="docs-content">
         <div class="docs-header">
           <h1>Community</h1>
-          
+
           <hr>
         </div>
         <div class="content block-content ready">
@@ -70,11 +70,9 @@
 </li>
 <li><a href="https://elixir-slackin.herokuapp.com/">Request an invitation</a> and join the #phoenix channel on <a href="https://elixir-lang.slack.com">Slack</a>.
 </li>
-<li>For general Phoenix questions, email the <a href="http://groups.google.com/group/phoenix-talk">phoenix-talk mailing list</a>.
-</li>
 <li>To discuss new features in the framework, email the <a href="http://groups.google.com/group/phoenix-core">phoenix-core mailing list</a>.
 </li>
-<li>Engage with other Elixir enthusiasts at <a href="https://elixirforum.com/">Elixir forum</a>.
+<li>Ask general Phoenix questions and engage with other Elixir enthusiasts at <a href="https://elixirforum.com/">Elixir forum</a>.
 </li>
 <li>Read about <a href="https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md#bug-reports">bug reports</a> or open an issue in the Phoenix <a href="https://github.com/phoenixframework/phoenix/issues">issue tracker</a>.
 </li>

--- a/pages/community.markdown
+++ b/pages/community.markdown
@@ -8,9 +8,8 @@ There are a number of places to connect with community members at all experience
 
 * We're on Freenode IRC in the [\#elixir-lang](http://webchat.freenode.net/?channels=elixir-lang) channel.
 * [Request an invitation](https://elixir-slackin.herokuapp.com/) and join the #phoenix channel on [Slack](https://elixir-lang.slack.com).
-* For general Phoenix questions, email the [phoenix-talk mailing list](http://groups.google.com/group/phoenix-talk).
 * To discuss new features in the framework, email the [phoenix-core mailing list](http://groups.google.com/group/phoenix-core).
-* Engage with other Elixir enthusiasts at [Elixir forum](https://elixirforum.com/).
+* Ask general Phoenix questions and engage with other Elixir enthusiasts at [Elixir forum](https://elixirforum.com/).
 * Read about [bug reports](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md#bug-reports) or open an issue in the Phoenix [issue tracker](https://github.com/phoenixframework/phoenix/issues).
 * Ask or answer questions about Phoenix on [Stack Overflow](http://stackoverflow.com/questions/tagged/phoenix-framework).
 * Follow the Phoenix Framework on [Twitter](https://twitter.com/elixirphoenix).


### PR DESCRIPTION
Following deprecation note https://groups.google.com/forum/#!topic/phoenix-talk/Z_Uk3foCyfY from
Chris, this patch removes references to `phoenix-talk` group and encourages users to visit elixirforum.com